### PR TITLE
Fix inference feature merge to combine partial records

### DIFF
--- a/real-time-data-forecasting-with-ai-and-python-4565024-03_10/real-time/inference.py
+++ b/real-time-data-forecasting-with-ai-and-python-4565024-03_10/real-time/inference.py
@@ -1,50 +1,132 @@
-from confluent_kafka import Consumer
-import pandas as pd
+from __future__ import annotations
+
 import json
-import joblib
 import warnings
+from pathlib import Path
+from typing import Iterable, List
+
+import joblib
+import numpy as np
+import pandas as pd
+from confluent_kafka import Consumer
 
 warnings.filterwarnings("ignore")
 
-def load_model(model_path):
-  model = joblib.load(model_path)
-  return model
+FEATURE_NAMES: List[str] = [
+    'lag_1',
+    'lag_2',
+    'lag_6',
+    'lag_12',
+    'lag_24',
+    'rolling_mean_7',
+    'rolling_std_7',
+    'hour',
+    'day_of_week',
+    'month',
+    'temperature_forecast',
+]
+MODEL_PATH = Path("models/energy_demand_model_v4.pkl")
 
-def fetch_all_feature_records():
-    # Kafka Consumer configuration for reading from the beginning of the topic
+
+def load_model(model_path: Path):
+    return joblib.load(model_path)
+
+
+def fetch_all_feature_records() -> List[dict]:
+    """Read feature records from Kafka until no new messages arrive."""
     conf = {
         'bootstrap.servers': "localhost:9092",
         'group.id': "feature_store_reader",
-        'auto.offset.reset': 'latest'
-        }
+        'auto.offset.reset': 'latest',
+    }
 
-    # Initialize Kafka Consumer and subscribe to the topic
     consumer = Consumer(conf)
     consumer.subscribe(['feature_store'])
 
-    feature_records = []  # List to store feature data
+    feature_records: List[dict] = []
 
     try:
         while True:
-            msg = consumer.poll(1)  # Poll for messages with a 1-second timeout
+            msg = consumer.poll(1)
             if msg is None:
-                break  # Exit loop if no more messages
-            if not msg.error():
-                # Convert message from JSON and add to list
-                feature_records.append(json.loads(msg.value().decode('utf-8')))
-            else:
-                break  # Exit loop on error
+                break
+            if msg.error():
+                break
+            feature_records.append(json.loads(msg.value().decode('utf-8')))
     finally:
-        consumer.close()  # Clean up: close consumer
+        consumer.close()
 
-    return feature_records  # Return the collected feature records
+    return feature_records
 
 
-latest_feature_record = pd.DataFrame(fetch_all_feature_records()).groupby('id').first().dropna().sort_index(ascending=False)[:1]
+def merge_feature_records(feature_records: Iterable[dict]) -> pd.DataFrame:
+    """Merge partial feature rows so each id has a single row with non-null values."""
+    records = list(feature_records)
+    if not records:
+        empty_frame = pd.DataFrame(columns=FEATURE_NAMES)
+        empty_frame.index.name = 'id'
+        return empty_frame
 
-feature_names = ['lag_1', 'lag_2', 'lag_6', 'lag_12', 'lag_24', 'rolling_mean_7', 'rolling_std_7', 'hour', 'day_of_week', 'month', 'temperature_forecast']
-latest_feature_record = latest_feature_record[feature_names]
+    frame = pd.DataFrame(records)
+    if 'id' not in frame.columns:
+        raise KeyError("Feature records must include an 'id' column.")
 
-model = load_model("models/energy_demand_model_v4.pkl")
-prediction = str(model.predict(latest_feature_record))
-print(f"Next 24 hours energy prediction = {prediction} Last updated:{str(latest_feature_record.index.to_list())}")
+    sort_columns = ['id']
+    if 'timestamp' in frame.columns:
+        frame = frame.copy()
+        frame['timestamp'] = pd.to_datetime(frame['timestamp'], errors='coerce')
+        sort_columns.append('timestamp')
+
+    sorted_frame = frame.sort_values(sort_columns)
+    merged = (
+        sorted_frame
+        .set_index('id')
+        .groupby(level=0)
+        .ffill()
+        .bfill()
+        .groupby(level=0)
+        .last()
+    )
+    merged.index.name = 'id'
+    return merged
+
+
+def prepare_latest_feature_record(feature_records: Iterable[dict]) -> pd.DataFrame:
+    merged = merge_feature_records(feature_records)
+    if merged.empty:
+        return merged
+
+    missing_columns = [name for name in FEATURE_NAMES if name not in merged.columns]
+    if missing_columns:
+        raise ValueError(f"Missing expected feature columns: {missing_columns}")
+
+    latest_feature_record = (
+        merged[FEATURE_NAMES]
+        .dropna()
+        .sort_index(ascending=False)
+        .head(1)
+    )
+    return latest_feature_record
+
+
+def predict_next_24_hours() -> tuple[np.ndarray, pd.DataFrame]:
+    latest_feature_record = prepare_latest_feature_record(fetch_all_feature_records())
+    if latest_feature_record.empty:
+        raise ValueError("No complete feature rows available for inference.")
+
+    model = load_model(MODEL_PATH)
+    prediction = model.predict(latest_feature_record)
+    return prediction, latest_feature_record
+
+
+def main() -> None:
+    prediction, latest_feature_record = predict_next_24_hours()
+    print(
+        "Next 24 hours energy prediction = "
+        f"{prediction.tolist()} "
+        f"Last updated:{latest_feature_record.index.to_list()}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_inference_feature_merge.py
+++ b/tests/test_inference_feature_merge.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pandas as pd
+from pandas.testing import assert_frame_equal
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+INFERENCE_DIR = PROJECT_ROOT / "real-time-data-forecasting-with-ai-and-python-4565024-03_10" / "real-time"
+if str(INFERENCE_DIR) not in sys.path:
+    sys.path.insert(0, str(INFERENCE_DIR))
+
+import inference  # noqa: E402
+
+
+def test_merge_feature_records_combines_partial_rows():
+    feature_records = [
+        {
+            "id": "row-1",
+            "lag_1": 1.0,
+            "lag_2": 2.0,
+            "timestamp": "2024-03-01T00:00:00Z",
+        },
+        {
+            "id": "row-1",
+            "temperature_forecast": 11.5,
+            "timestamp": "2024-03-01T00:05:00Z",
+        },
+    ]
+
+    merged = inference.merge_feature_records(feature_records)
+
+    expected = pd.DataFrame(
+        {
+            "lag_1": [1.0],
+            "lag_2": [2.0],
+            "timestamp": pd.to_datetime(["2024-03-01T00:05:00Z"]),
+            "temperature_forecast": [11.5],
+        },
+        index=pd.Index(["row-1"], name="id"),
+    )
+
+    assert_frame_equal(merged.loc[:, expected.columns], expected)


### PR DESCRIPTION
## Summary
- restructure the inference pipeline to merge Kafka feature rows per id before selecting model features
- ensure runtime execution is guarded and keep feature filtering with dropna so only complete rows are used
- add a pytest covering the merge logic to confirm lag features and temperature forecasts land on the same row

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3540c76b08320afde96fb3a7fd722