### PR TITLE
Add guards for missing feature records during inference

### DIFF
--- a/tests/test_inference_no_records.py
+++ b/tests/test_inference_no_records.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+INFERENCE_DIR = PROJECT_ROOT / "real-time-data-forecasting-with-ai-and-python-4565024-03_10" / "real-time"
+if str(INFERENCE_DIR) not in sys.path:
+    sys.path.insert(0, str(INFERENCE_DIR))
+
+import inference  # noqa: E402
+
+
+def test_predict_next_24_hours_with_no_feature_records(monkeypatch, caplog):
+    monkeypatch.setattr(inference, "fetch_all_feature_records", lambda: [])
+
+    with caplog.at_level("WARNING"):
+        with pytest.raises(ValueError) as excinfo:
+            inference.predict_next_24_hours()
+
+    assert "No feature records retrieved for inference" in str(excinfo.value)
+    assert any(
+        "No feature records retrieved for inference" in message
+        for message in caplog.messages
+    )


### PR DESCRIPTION
## Summary
- add logging guard before inference to handle missing feature records
- skip prediction when aggregated feature rows are unavailable
- cover the new guard path with a unit test for empty feature fetches

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e357b6d8648320aeaf805df739016a