### PR TITLE
Refine inference feature merging and add tests

### DIFF
--- a/real-time-data-forecasting-with-ai-and-python-4565024-03_09/real-time/inference.py
+++ b/real-time-data-forecasting-with-ai-and-python-4565024-03_09/real-time/inference.py
@@ -1,50 +1,115 @@
-from confluent_kafka import Consumer
-import pandas as pd
+from collections import defaultdict
 import json
+from typing import Iterable, Mapping, Sequence, Any, Dict
+
+from confluent_kafka import Consumer
 import joblib
+import pandas as pd
 import warnings
 
 warnings.filterwarnings("ignore")
 
-def load_model(model_path):
-  model = joblib.load(model_path)
-  return model
+
+REQUIRED_FEATURE_COLUMNS = [
+    "lag_1",
+    "lag_2",
+    "lag_6",
+    "lag_12",
+    "lag_24",
+    "rolling_mean_7",
+    "rolling_std_7",
+    "hour",
+    "day_of_week",
+    "month",
+    "temperature_forecast",
+]
+
+
+def load_model(model_path: str):
+    return joblib.load(model_path)
+
 
 def fetch_all_feature_records():
-    # Kafka Consumer configuration for reading from the beginning of the topic
     conf = {
-        'bootstrap.servers': "localhost:9092",
-        'group.id': "feature_store_reader",
-        'auto.offset.reset': 'latest'
-        }
+        "bootstrap.servers": "localhost:9092",
+        "group.id": "feature_store_reader",
+        "auto.offset.reset": "latest",
+    }
 
-    # Initialize Kafka Consumer and subscribe to the topic
     consumer = Consumer(conf)
-    consumer.subscribe(['feature_store'])
+    consumer.subscribe(["feature_store"])
 
-    feature_records = []  # List to store feature data
+    feature_records = []
 
     try:
         while True:
-            msg = consumer.poll(1)  # Poll for messages with a 1-second timeout
+            msg = consumer.poll(1)
             if msg is None:
-                break  # Exit loop if no more messages
-            if not msg.error():
-                # Convert message from JSON and add to list
-                feature_records.append(json.loads(msg.value().decode('utf-8')))
-            else:
-                break  # Exit loop on error
+                break
+            if msg.error():
+                break
+            feature_records.append(json.loads(msg.value().decode("utf-8")))
     finally:
-        consumer.close()  # Clean up: close consumer
+        consumer.close()
 
-    return feature_records  # Return the collected feature records
+    return feature_records
 
 
-latest_feature_record = pd.DataFrame(fetch_all_feature_records()).groupby('id').first().dropna().sort_index(ascending=False)[:1]
+def build_feature_frame(
+    records: Iterable[Mapping[str, Any]],
+    required_columns: Sequence[str],
+) -> pd.DataFrame:
+    if required_columns is None:
+        raise ValueError("required_columns must be provided")
 
-feature_names = ['lag_1', 'lag_2', 'lag_6', 'lag_12', 'lag_24', 'rolling_mean_7', 'rolling_std_7', 'hour', 'day_of_week', 'month', 'temperature_forecast']
-latest_feature_record = latest_feature_record[feature_names]
+    merged_records: Dict[Any, Dict[str, Any]] = defaultdict(dict)
 
-model = load_model("models/energy_demand_model_v4.pkl")
-prediction = str(model.predict(latest_feature_record))
-print(f"Next 24 hours energy prediction = {prediction} Last updated:{str(latest_feature_record.index.to_list())}")
+    for payload in records or []:
+        if not isinstance(payload, Mapping):
+            raise TypeError("Feature records must be mappings")
+        if "id" not in payload:
+            raise ValueError("Feature record is missing required 'id' field")
+
+        record_id = payload["id"]
+        if record_id is None:
+            raise ValueError("Feature record has null 'id'")
+
+        for key, value in payload.items():
+            if key == "id":
+                continue
+            merged_records[record_id][key] = value
+
+    frame = pd.DataFrame.from_dict(merged_records, orient="index")
+    if frame.empty:
+        return frame.reindex(columns=list(required_columns))
+
+    frame.index.name = "id"
+    frame = frame.reindex(columns=list(required_columns))
+    frame = frame.dropna(subset=required_columns)
+    return frame
+
+
+def prepare_latest_feature_record() -> pd.DataFrame:
+    feature_records = fetch_all_feature_records()
+    feature_frame = build_feature_frame(feature_records, REQUIRED_FEATURE_COLUMNS)
+    if feature_frame.empty:
+        raise ValueError("No feature records available with all required columns")
+
+    return feature_frame.sort_index(ascending=False).head(1)
+
+
+def run_inference(model_path: str = "models/energy_demand_model_v4.pkl") -> pd.DataFrame:
+    latest_feature_record = prepare_latest_feature_record()
+    model = load_model(model_path)
+    prediction = model.predict(latest_feature_record)
+    print(
+        "Next 24 hours energy prediction = {prediction} Last updated:{timestamps}".format(
+            prediction=str(prediction),
+            timestamps=str(latest_feature_record.index.to_list()),
+        )
+    )
+    return latest_feature_record
+
+
+if __name__ == "__main__":
+    run_inference()

--- a/real-time-data-forecasting-with-ai-and-python-4565024-03_09/real-time/tests/test_inference_features.py
+++ b/real-time-data-forecasting-with-ai-and-python-4565024-03_09/real-time/tests/test_inference_features.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+import sys
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.append(str(PROJECT_ROOT))
+
+import inference
+
+
+def test_build_feature_frame_merges_partial_records():
+    required_columns = [
+        "lag_1",
+        "lag_2",
+        "lag_6",
+        "lag_12",
+        "lag_24",
+        "rolling_mean_7",
+        "rolling_std_7",
+        "hour",
+        "day_of_week",
+        "month",
+        "temperature_forecast",
+    ]
+
+    records = [
+        {
+            "id": "2024-05-12T01:00:00",
+            "lag_1": 100,
+            "lag_2": 110,
+            "lag_6": 150,
+            "lag_12": 170,
+            "lag_24": 200,
+            "rolling_mean_7": 145.0,
+            "rolling_std_7": 5.5,
+            "hour": 1,
+            "day_of_week": 6,
+            "month": 5,
+        },
+        {
+            "id": "2024-05-12T01:00:00",
+            "temperature_forecast": 22.5,
+        },
+    ]
+
+    feature_frame = inference.build_feature_frame(records, required_columns)
+
+    assert feature_frame.shape[0] == 1
+    assert list(feature_frame.index) == ["2024-05-12T01:00:00"]
+    assert list(feature_frame.columns) == required_columns
+    assert feature_frame.notna().all().all()


### PR DESCRIPTION
## Summary
- refactor the inference pipeline to merge feature records by identifier and drop incomplete entries before prediction
- add a reusable build_feature_frame helper and guard the script with a main entry point for easier testing
- cover the merge behaviour with a new pytest case

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e359605a64832085512e80e204f6cb