### PR TITLE
Refine inference feature merging logic

### DIFF
--- a/real-time-data-forecasting-with-ai-and-python-4565024-03_09/real-time/tests/test_inference_features.py
+++ b/real-time-data-forecasting-with-ai-and-python-4565024-03_09/real-time/tests/test_inference_features.py
@@ -1,0 +1,61 @@
+from importlib import util
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+
+def load_inference_module():
+    module_path = (
+        Path(__file__).resolve().parents[1]
+        / "inference.py"
+    )
+    spec = util.spec_from_file_location("inference", module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("Unable to load inference module for testing.")
+    module = util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_build_feature_frame_merges_partial_records():
+    inference = load_inference_module()
+    lag_record = {
+        "id": "2024-03-01T00:00:00Z",
+        "lag_1": 100.0,
+        "lag_2": 90.0,
+        "lag_6": 80.0,
+        "lag_12": 70.0,
+        "lag_24": 60.0,
+        "rolling_mean_7": 85.0,
+        "rolling_std_7": 5.0,
+        "hour": 0,
+        "day_of_week": 4,
+        "month": 3,
+    }
+    temperature_record = {
+        "id": "2024-03-01T00:00:00Z",
+        "temperature_forecast": -2.0,
+    }
+
+    frame = inference.build_feature_frame(
+        records=[lag_record, temperature_record],
+        required_columns=inference.FEATURE_NAMES,
+    )
+
+    assert isinstance(frame, pd.DataFrame)
+    assert list(frame.columns) == inference.FEATURE_NAMES
+    assert len(frame) == 1
+    assert frame.iloc[0].to_dict() == pytest.approx({
+        "lag_1": 100.0,
+        "lag_2": 90.0,
+        "lag_6": 80.0,
+        "lag_12": 70.0,
+        "lag_24": 60.0,
+        "rolling_mean_7": 85.0,
+        "rolling_std_7": 5.0,
+        "hour": 0,
+        "day_of_week": 4,
+        "month": 3,
+        "temperature_forecast": -2.0,
+    })


### PR DESCRIPTION
## Summary
- add a reusable helper that groups feature records by id and merges partial payloads
- ensure inference drops incomplete feature rows before prediction
- add a regression test covering merged feature construction

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e35ab9c63c8320be60161b4a4812b5