### PR TITLE
Normalize timestamps before merging feature records

### DIFF
--- a/tests/test_inference_feature_merge.py
+++ b/tests/test_inference_feature_merge.py
@@ -27,7 +27,8 @@ def test_merge_feature_records_combines_partial_rows():
         {
             "id": "row-1",
             "temperature_forecast": 11.5,
-            "timestamp": "2024-03-01T00:05:00Z",
+            # Intentional naive timestamp to verify normalization across records
+            "timestamp": "2024-03-01T00:05:00",
         },
     ]
 
@@ -37,7 +38,7 @@ def test_merge_feature_records_combines_partial_rows():
         {
             "lag_1": [1.0],
             "lag_2": [2.0],
-            "timestamp": pd.to_datetime(["2024-03-01T00:05:00Z"]),
+            "timestamp": pd.to_datetime(["2024-03-01T00:05:00"]),
             "temperature_forecast": [11.5],
         },
         index=pd.Index(["row-1"], name="id"),


### PR DESCRIPTION
## Summary
- normalize timestamp values while merging feature records so mixed tz-aware/naive data sorts safely
- fall back to arrival order when timestamp normalization fails to avoid inference crashes
- update feature merge tests to cover mixed timezone inputs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e35d6416688320a955fe838bed2537